### PR TITLE
Bump dev addon to tududi v1.0.0-dev.1

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.0.0-dev.1
+**BUMPED:** bumped to tududi v1.0.0-dev.1 (pre-release)
+
+**IMPROVED:** Zero sed fixes in Dockerfile
+- Removed logo path sed workaround — fixed upstream in PR #946
+  (Navbar.tsx and Login.tsx now use getAssetPath() for logo paths)
+- Dockerfile now has zero sed fixes, all path issues resolved upstream
+
+**TUDUDI v1.0.0-dev.1 CHANGELOG:**
+- Add comprehensive LLM development documentation by @chrisvel in #939
+- Fix date format inconsistency in Defer Until field by @chrisvel in #941
+- Add URL detection to inbox processing service by @chrisvel in #942
+- Fix notification deduplication to prevent pile-up in navbar by @chrisvel in #945
+- fix: use getAssetPath() for logo images in Navbar and Login by @woytekbode in #946
+
 ## 0.89.0
 **BUMPED:** bumped to tududi v0.89.0 (stable release)
 

--- a/tududi-addon-dev/Dockerfile
+++ b/tududi-addon-dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # To update the version, change the branch tag on the git clone line below
-RUN git clone --depth 1 --branch v0.89.0 https://github.com/chrisvel/tududi.git /tmp/tududi && \
+RUN git clone --depth 1 --branch v1.0.0-dev.1 https://github.com/chrisvel/tududi.git /tmp/tududi && \
     cd /tmp/tududi && \
     npm config set fetch-retry-maxtimeout 300000 && \
     npm config set fetch-retry-mintimeout 20000 && \
@@ -26,18 +26,8 @@ RUN git clone --depth 1 --branch v0.89.0 https://github.com/chrisvel/tududi.git 
     npm install i18next --save --no-audit --no-fund --legacy-peer-deps && \
     NODE_OPTIONS="--max-old-space-size=2048" NODE_ENV=production npm run frontend:build && \
     # Upstream webpack publicPath is already '' (relative), and index.html has
-    # a dynamic <base> tag that detects HA ingress. No index.html sed needed.
-    #
-    # TODO: Remove this sed workaround once the addon bumps to a tududi version
-    # that includes PR #946 (https://github.com/chrisvel/tududi/pull/946).
-    # The fix is merged to main but not yet in a release. It makes Navbar.tsx
-    # and Login.tsx use getAssetPath() for logo paths instead of hardcoded
-    # absolute paths.
-    find dist -name "*.js" -type f -exec sed -i \
-        -e 's|"/wide-logo-light.png"|"./wide-logo-light.png"|g' \
-        -e "s|'/wide-logo-light.png'|'./wide-logo-light.png'|g" \
-        -e 's|"/wide-logo-dark.png"|"./wide-logo-dark.png"|g' \
-        -e "s|'/wide-logo-dark.png'|'./wide-logo-dark.png'|g" {} + && \
+    # a dynamic <base> tag that detects HA ingress. No sed fixes needed.
+    # Logo paths fixed upstream in PR #946 (included in v1.0.0-dev.1).
     mkdir -p /app/backend /app/backend/dist /app/backend/dist/locales /app/node_modules && \
     cp -r backend/* /app/backend/ && \
     cp -r dist/* /app/backend/dist/ && \

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "0.89.0"
+version: "1.0.0-dev.1"
 slug: "tududi-dev"
-description: "Development version of Tududi (v0.89.0) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.0.0-dev.1) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false


### PR DESCRIPTION
## Description

Bump the dev addon from tududi v0.89.0 to v1.0.0-dev.1. This release includes the logo path fix (chrisvel/tududi#946), allowing us to remove the last remaining sed workaround from the Dockerfile — zero sed fixes now.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
    - [ ] Referenced the bug 
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] was there a feature request, if yes, linked
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [x] Bump Dependancies

## Changes Made

- Update git clone tag from `v0.89.0` to `v1.0.0-dev.1` in Dockerfile
- Remove logo path sed workaround entirely (fixed upstream in [chrisvel/tududi#946](https://github.com/chrisvel/tududi/pull/946))
- Zero sed fixes remaining in Dockerfile
- Update `config.yaml` version (`0.89.0` → `1.0.0-dev.1`) and description
- Update CHANGELOG.md with new entry

## Testing

- [x] Local testing completed
- [x] Add-on builds successfully
- [x] Tested in Home Assistant
- [x] No breaking changes confirmed

## Add-on Affected

- [ ] Stable addon (`tududi-addon`)
- [x] Development addon (`tududi-addon-dev`)
- [ ] Repository configuration
- [ ] CI/CD workflows

## Checklist

- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Documentation updated (if needed)
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Screenshots (if applicable)

## Additional Notes

### Upstream changelog (v1.0.0-dev.1)
- Add comprehensive LLM development documentation by @chrisvel in #939
- Fix date format inconsistency in Defer Until field by @chrisvel in #941
- Add URL detection to inbox processing service by @chrisvel in #942
- Fix notification deduplication to prevent pile-up in navbar by @chrisvel in #945
- fix: use getAssetPath() for logo images in Navbar and Login by @woytekbode in #946