### PR TITLE
Bump dev addon to tududi v1.0.0-rc.1

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.0.0-rc.1
+**BUMPED:** bumped to tududi v1.0.0-rc.1 (release candidate)
+
+**TUDUDI v1.0.0-rc.1 CHANGELOG (since v1.0.0-dev.1):**
+- Fix Telegram notification spam with channel-level rate limiting by @chrisvel in #951
+- Add MCP Integration with client-agnostic instructions by @chrisvel in #953
+- Fix date format inconsistency in Task detail screen by @chrisvel in #956
+
 ## 1.0.0-dev.1
 **BUMPED:** bumped to tududi v1.0.0-dev.1 (pre-release)
 

--- a/tududi-addon-dev/Dockerfile
+++ b/tududi-addon-dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # To update the version, change the branch tag on the git clone line below
-RUN git clone --depth 1 --branch v1.0.0-dev.1 https://github.com/chrisvel/tududi.git /tmp/tududi && \
+RUN git clone --depth 1 --branch v1.0.0-rc.1 https://github.com/chrisvel/tududi.git /tmp/tududi && \
     cd /tmp/tududi && \
     npm config set fetch-retry-maxtimeout 300000 && \
     npm config set fetch-retry-mintimeout 20000 && \

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "1.0.0-dev.1"
+version: "1.0.0-rc.1"
 slug: "tududi-dev"
-description: "Development version of Tududi (v1.0.0-dev.1) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.0.0-rc.1) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false


### PR DESCRIPTION
## Description

Bump the development addon to track upstream tududi v1.0.0-rc.1 (release candidate).

This is a straightforward version bump — no addon-level changes, just pointing at the new upstream tag.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
    - [ ] Referenced the bug 
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] was there a feature request, if yes, linked
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [x] Bump Dependancies

## Changes Made

- Update `config.yaml` version and description to `1.0.0-rc.1`
- Update Dockerfile git clone tag to `v1.0.0-rc.1`
- Update CHANGELOG with upstream changes since `v1.0.0-dev.1`:
  - Fix Telegram notification spam with channel-level rate limiting (chrisvel/tududi#951)
  - Add MCP Integration with client-agnostic instructions (chrisvel/tududi#953)
  - Fix date format inconsistency in Task detail screen (chrisvel/tududi#956)

## Testing

- [ ] Local testing completed
- [x] Add-on builds successfully
- [ ] Tested in Home Assistant
- [x] No breaking changes confirmed

## Add-on Affected

- [ ] Stable addon (`tududi-addon`)
- [x] Development addon (`tududi-addon-dev`)
- [ ] Repository configuration
- [ ] CI/CD workflows

## Checklist

- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Documentation updated (if needed)
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Screenshots (if applicable)

N/A — version bump only, no UI changes on the addon side.

## Additional Notes

After merging, run the builder workflow: Actions → 🏗️📢 Build and Publish Add-on → `dev`.