### PR TITLE
Bump dev addon to tududi v1.0.0-rc.2

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.0.0-rc.2
+**BUMPED:** bumped to tududi v1.0.0-rc.2 (release candidate)
+
+**TUDUDI v1.0.0-rc.2 CHANGELOG (since v1.0.0-rc.1):**
+- Fix visual overlap between subtasks icon and status dropdown by @chrisvel in #958
+- Fix project update API to support clearing nullable fields by @chrisvel in #961
+- Fix recurring task initial due date calculation to match recurrence pattern by @chrisvel in #965
+- Fix Telegram notification spam by marking JSON field as changed by @chrisvel in #969
+- Fix Today page task completion issues by @chrisvel in #970
+- Fix project name overflow and add 6-word validation limit by @chrisvel in #972
+
 ## 1.0.0-rc.1
 **BUMPED:** bumped to tududi v1.0.0-rc.1 (release candidate)
 

--- a/tududi-addon-dev/Dockerfile
+++ b/tududi-addon-dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # To update the version, change the branch tag on the git clone line below
-RUN git clone --depth 1 --branch v1.0.0-rc.1 https://github.com/chrisvel/tududi.git /tmp/tududi && \
+RUN git clone --depth 1 --branch v1.0.0-rc.2 https://github.com/chrisvel/tududi.git /tmp/tududi && \
     cd /tmp/tududi && \
     npm config set fetch-retry-maxtimeout 300000 && \
     npm config set fetch-retry-mintimeout 20000 && \

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "1.0.0-rc.1"
+version: "1.0.0-rc.2"
 slug: "tududi-dev"
-description: "Development version of Tududi (v1.0.0-rc.1) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.0.0-rc.2) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false


### PR DESCRIPTION
## Description
Bumps the development addon from tududi v1.0.0-rc.1 to v1.0.0-rc.2.

## Type of Change
- [x] Bump Dependencies

## Changes Made
- `config.yaml` — version `1.0.0-rc.1` → `1.0.0-rc.2`, description updated
- `Dockerfile` — git clone tag `v1.0.0-rc.1` → `v1.0.0-rc.2`
- `CHANGELOG.md` — new entry for `1.0.0-rc.2`

## Testing
- [ ] Local testing completed
- [ ] Add-on builds successfully
- [ ] Tested in Home Assistant
- [x] No breaking changes confirmed

## Add-on Affected
- [x] Development addon (`tududi-addon-dev`)

## Checklist
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Additional Notes
Upstream changes in tududi v1.0.0-rc.2 (since v1.0.0-rc.1):
- Fix visual overlap between subtasks icon and status dropdown by @chrisvel in chrisvel/tududi#958
- Fix project update API to support clearing nullable fields by @chrisvel in chrisvel/tududi#961
- Fix recurring task initial due date calculation to match recurrence pattern by @chrisvel in chrisvel/tududi#965
- Fix Telegram notification spam by marking JSON field as changed by @chrisvel in chrisvel/tududi#969
- Fix Today page task completion issues by @chrisvel in chrisvel/tududi#970
- Fix project name overflow and add 6-word validation limit by @chrisvel in chrisvel/tududi#972