### PR TITLE
Bump dev addon to tududi v1.1.0-dev.14

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.1.0-dev.14
+**BUMPED:** bumped to tududi v1.1.0-dev.14 (pre-release)
+
+**TUDUDI v1.1.0-dev.14 CHANGELOG:**
+- fix: resolve OIDC session loss and migration failures by @chrisvel in #1023
+- build(deps): bump follow-redirects from 1.15.11 to 1.16.0 by @dependabot in #1024
+- fix: add CSRF token support to frontend requests by @chrisvel in #1025
+
+**TUDUDI v1.1.0-dev.7 CHANGELOG:**
+- fix: resolve OIDC authentication error with existing identities by @chrisvel in #1021
+
+**TUDUDI v1.1.0-dev.6 CHANGELOG:**
+- fix: allow Sunday selection in monthly weekday recurring tasks by @chrisvel in #1014
+- fix: correct Sequelize alias case for OIDCIdentity-User association by @chrisvel in #1015
+- fix: resolve inbox project creation bugs by @chrisvel in #1018
+- fix: prevent Telegram polling errors from blocking container startup by @chrisvel in #1019
+- fix: prevent task name truncation when creating from inbox by @chrisvel in #1020
+
+**TUDUDI v1.1.0-dev.5 CHANGELOG:**
+- feat: Add OIDC/SSO authentication support by @chrisvel in #1008
+- Fix: Resolve 20 security vulnerabilities in dependencies by @chrisvel in #983
+- Fix: Prevent subtasks from disappearing when updating parent task by @chrisvel in #984
+- Fix: Bi-weekly recurring task scheduling for multi-day patterns by @chrisvel in #1005
+- fix: add missing i18next dependency to package.json by @chrisvel in #1006
+- fix: exclude cancelled tasks from Overdue and Due Today sections by @chrisvel in #1007
+- fix: use correct InboxItem model name in MCP inbox tools by @oritromax in #986
+- Bump hono from 4.12.8 to 4.12.12 by @dependabot in #1012
+- Bump @hono/node-server from 1.19.11 to 1.19.13 by @dependabot in #1011
+- Bump lodash from 4.17.23 to 4.18.1 by @dependabot in #1010
+- Bump nodemailer from 8.0.4 to 8.0.5 by @dependabot in #1009
+
+**TUDUDI v1.0.0 CHANGELOG (additions since v1.0.0-rc.3):**
+- docs: Clarify tag validation rules and Inbox hashtag syntax by @vincent067 in #964
+
 ## 1.0.0-rc.3
 **BUMPED:** bumped to tududi v1.0.0-rc.3 (release candidate)
 

--- a/tududi-addon-dev/Dockerfile
+++ b/tududi-addon-dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # To update the version, change the branch tag on the git clone line below
-RUN git clone --depth 1 --branch v1.0.0-rc.3 https://github.com/chrisvel/tududi.git /tmp/tududi && \
+RUN git clone --depth 1 --branch v1.1.0-dev.14 https://github.com/chrisvel/tududi.git /tmp/tududi && \
     cd /tmp/tududi && \
     npm config set fetch-retry-maxtimeout 300000 && \
     npm config set fetch-retry-mintimeout 20000 && \

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "1.0.0-rc.3"
+version: "1.1.0-dev.14"
 slug: "tududi-dev"
-description: "Development version of Tududi (v1.0.0-rc.3) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.1.0-dev.14) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false


### PR DESCRIPTION
## Description
Bumps the development addon from tududi `v1.0.0-rc.3` to `v1.1.0-dev.14` (latest upstream pre-release). Pure version bump — no addon-side feature changes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
    - [ ] Referenced the bug
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] was there a feature request, if yes, linked
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [x] Bump Dependancies

## Changes Made
- `tududi-addon-dev/config.yaml`: version `1.0.0-rc.3` → `1.1.0-dev.14`, description string updated to match.
- `tududi-addon-dev/Dockerfile`: `git clone --branch` tag → `v1.1.0-dev.14`.
- `tududi-addon-dev/CHANGELOG.md`: new `1.1.0-dev.14` entry listing upstream PRs grouped per release (v1.0.0 additions, v1.1.0-dev.5/6/7/14).

## Testing
- [ ] Local testing completed
- [ ] Add-on builds successfully
- [ ] Tested in Home Assistant
- [x] No breaking changes confirmed

## Add-on Affected
- [ ] Stable addon (`tududi-addon`)
- [x] Development addon (`tududi-addon-dev`)
- [ ] Repository configuration
- [ ] CI/CD workflows

## Checklist
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Documentation updated (if needed)
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Screenshots (if applicable)
N/A — no UI changes.

## Additional Notes
**Upstream changes since v1.0.0-rc.3** span `v1.0.0`, `v1.1.0-dev.5`, `dev.6`, `dev.7`, `dev.14`. Highlights:
- **feat:** OIDC/SSO authentication support (#1008)
- **feat:** CSRF token support on frontend requests (#1025)
- **fix:** Resolve 20 dependency security vulnerabilities (#983)
- **fix:** Multiple recurring-task bugs (bi-weekly, Sunday-in-monthly, OIDC session loss)
- Plus inbox, Telegram, and dependency updates — see the CHANGELOG entry for the full per-release list.

MCP server (`FF_ENABLE_MCP`) is already baked into this upstream version but is not yet exposed through addon options; a follow-up PR will add an `ff_enable_mcp` toggle.

**After merge:** run **Actions → "🏗️📢 Build and Publish Add-on"** with the `dev` target to publish `ghcr.io/c2gl/tududi-addon-dev:1.1.0-dev.14`.