### PR TITLE
Trust proxy fix for HA ingress (1.1.0-dev.14.1)

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.1.0-dev.14.1
+**FIXED:** 401-after-login regression behind HA ingress
+- Export `TUDUDI_TRUST_PROXY=true` so Tududi calls
+  `app.set('trust proxy', true)`. Without this, Express ignores the
+  `X-Forwarded-*` headers from HA ingress; combined with the upstream
+  change in v1.0.0+ (#1008) that ties `cookie.secure` to `NODE_ENV`,
+  the secure session cookie set on `/api/login` was not honored on the
+  round-trip and every subsequent `/api/*` returned 401, bouncing the
+  frontend to a 404 route.
+- Addon-side patch only — still pinned to upstream tududi v1.1.0-dev.14.
+- Upstream context: chrisvel/tududi#1023.
+
 ## 1.1.0-dev.14
 **BUMPED:** bumped to tududi v1.1.0-dev.14 (pre-release)
 

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "1.1.0-dev.14"
+version: "1.1.0-dev.14.1"
 slug: "tududi-dev"
-description: "Development version of Tududi (v1.1.0-dev.14) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.1.0-dev.14, addon patch .1) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false

--- a/tududi-addon-dev/run.sh
+++ b/tududi-addon-dev/run.sh
@@ -150,6 +150,18 @@ log_info "Database file set to ${DB_FILE}"
 # Set NODE_ENV to production
 export NODE_ENV=production
 
+# Trust proxy - required because HA ingress is a reverse proxy in front of
+# the addon. Without this, Express ignores X-Forwarded-* headers, so:
+#   * req.secure is false even though the client connection is HTTPS
+#   * the secure-flagged session cookie set on /api/login is not honored
+#     on the round-trip -> every subsequent /api/* returns 401
+# This regression became visible in tududi v1.0.0+ after upstream #1008
+# tied cookie.secure to NODE_ENV (now true here). Defaulting trust proxy on
+# is safe because HA ingress is always the reverse proxy in front of an
+# addon. Upstream context: chrisvel/tududi#1023.
+export TUDUDI_TRUST_PROXY=true
+log_info "Trust proxy enabled for HA ingress"
+
 # Set CORS allowed origins for Home Assistant ingress
 # Use wildcard to allow all origins when behind ingress proxy
 # Home Assistant's ingress handles the actual security


### PR DESCRIPTION
## Description
Fixes a 401-after-login regression on every `/api/*` request behind HA ingress in the dev addon, introduced when bumping to tududi v1.1.0-dev.14. Addon-patch version bump to `1.1.0-dev.14.1` so HA shows users an "Update available".

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
    - [ ] Referenced the bug
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] was there a feature request, if yes, linked
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [ ] Bump Dependancies

## Changes Made
- `tududi-addon-dev/run.sh`: export `TUDUDI_TRUST_PROXY=true` so Tududi calls `app.set('trust proxy', true)`. Without this, Express ignores the `X-Forwarded-*` headers from HA ingress; combined with upstream PR #1008 tying `cookie.secure` to `NODE_ENV`, the secure session cookie set on `/api/login` was not honored on the round-trip and every subsequent `/api/*` returned 401.
- `tududi-addon-dev/config.yaml`: addon version `1.1.0-dev.14` → `1.1.0-dev.14.1`, description notes the addon patch.
- `tududi-addon-dev/CHANGELOG.md`: new `1.1.0-dev.14.1` entry.

## Testing
- [x] Local testing completed
- [ ] Add-on builds successfully
- [x] Tested in Home Assistant
- [x] No breaking changes confirmed

## Add-on Affected
- [ ] Stable addon (`tududi-addon`)
- [x] Development addon (`tududi-addon-dev`)
- [ ] Repository configuration
- [ ] CI/CD workflows

## Checklist
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Documentation updated (if needed)
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Screenshots (if applicable)

## Additional Notes
- Versioning rationale: `1.1.0-dev.14.1` is valid SemVer 2.0 (the pre-release identifier `dev.14.1` adds one segment to `dev.14`). Per SemVer §11.4.4, the larger pre-release set wins when prefixes match, so HA's `awesomeversion` library will recognize this as `> 1.1.0-dev.14` and prompt the update. Addon stays pinned to upstream tududi `v1.1.0-dev.14` — no upstream bump.
- Verified upstream code at `chrisvel/tududi@v1.1.0-dev.14`: `backend/config/config.js` reads `TUDUDI_TRUST_PROXY` env var and `backend/app.js` calls `app.set('trust proxy', config.trustProxy)` when it's not `false`. Upstream PR #1023 documented this env var as the recommended fix.
- HA ingress is always a trusted reverse proxy in front of an addon, so defaulting `TUDUDI_TRUST_PROXY=true` is safe for every HA install.
- After merge: run the builder workflow targeting `dev` to publish `ghcr.io/c2gl/tududi-addon-dev:1.1.0-dev.14.1`. Updating from HA will then resolve the 401 issue for users.
- The same regression will hit the stable addon when it eventually bumps past `v1.0.0`. Worth pre-applying the same `run.sh` change in a future stable PR.