### PR TITLE
Expose TUDUDI_TRUST_PROXY and FF_ENABLE_MCP as HA config toggles (1.1…

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.1.0-dev.14.2
+**ADDED:** Two HA config toggles for upstream Tududi feature flags
+
+- `tududi_trust_proxy` (default `true`) — now exposed as a user option.
+  Controls `TUDUDI_TRUST_PROXY`. Previously hardcoded to `true` in `.14.1`.
+  Keep on for HA Ingress (the reverse proxy in front of every HA addon);
+  disable only in advanced non-ingress setups where the upstream proxy is
+  not trusted. `run.sh` logs a warning when disabled.
+- `ff_enable_mcp` (default `false`) — new option, controls `FF_ENABLE_MCP`.
+  When enabled, tududi exposes `/api/mcp/*` endpoints protected by a Bearer
+  API token. Users must generate an API token in Profile → API Keys to use
+  the server. Matches upstream default.
+
+Friendly names and descriptions for both options added in
+`translations/en.yaml` so they render nicely in the HA config UI.
+
+Addon-side change only — still pinned to upstream tududi v1.1.0-dev.14.
+
 ## 1.1.0-dev.14.1
 **FIXED:** 401-after-login regression behind HA ingress
 - Export `TUDUDI_TRUST_PROXY=true` so Tududi calls

--- a/tududi-addon-dev/README.md
+++ b/tududi-addon-dev/README.md
@@ -45,6 +45,8 @@ port: 3002
 tududi_user_email: "your-email@example.com"
 tududi_user_password: "your-secure-password"
 tududi_session_secret: "your-random-secret-string"
+tududi_trust_proxy: true
+ff_enable_mcp: false
 disable_telegram: false
 disable_scheduler: false
 upload_path: "/data/uploads"
@@ -59,6 +61,8 @@ db_file: "/data/production.sqlite3"
 | `tududi_user_email` | Yes* | - | Email for the default admin user |
 | `tududi_user_password` | Yes* | - | Password for the default admin user |
 | `tududi_session_secret` | Yes* | - | Secret key for session encryption |
+| `tududi_trust_proxy` | No | `true` | Trust `X-Forwarded-*` headers from the reverse proxy. Required for HA Ingress. Only disable for advanced non-ingress setups. |
+| `ff_enable_mcp` | No | `false` | Enable the Tududi MCP server endpoints (`/api/mcp/*`). Requires an API token generated in the Tududi UI under Profile → API Keys. |
 | `disable_telegram` | No | `false` | Disable Telegram integration |
 | `disable_scheduler` | No | `false` | Disable the task scheduler |
 | `upload_path` | No | `/data/uploads` | Path for file uploads |
@@ -72,6 +76,20 @@ You can generate a secure session secret using:
 ```bash
 openssl rand -hex 32
 ```
+
+### About `tududi_trust_proxy`
+
+Home Assistant Ingress acts as a reverse proxy in front of every addon. Tududi needs to trust the `X-Forwarded-*` headers it adds so that `req.secure` is honored on the request round-trip; without it the secure-flagged session cookie set on login is rejected on the next request and every `/api/*` call returns 401. The toggle defaults to `true` for this reason — only disable it in advanced non-ingress setups where the upstream proxy is not trusted.
+
+### About `ff_enable_mcp`
+
+Tududi ships an optional MCP (Model Context Protocol) server that exposes task and inbox tools over HTTP at `/api/mcp/*`. Because MCP calls are authenticated with a Bearer API token (not your session cookie), you must:
+
+1. Enable `ff_enable_mcp: true` in the addon config.
+2. Log into the Tududi web UI, open your profile, go to **API Keys**, and generate a token.
+3. Point your MCP client at the ingress URL, passing the token as `Authorization: Bearer <token>`.
+
+The flag matches the upstream `FF_ENABLE_MCP` environment variable and is off by default.
 
 ## Backup Support
 

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "1.1.0-dev.14.1"
+version: "1.1.0-dev.14.2"
 slug: "tududi-dev"
-description: "Development version of Tududi (v1.1.0-dev.14, addon patch .1) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.1.0-dev.14, addon patch .2) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false
@@ -32,6 +32,8 @@ options:
   # A cryptographically strong secret is auto-generated on first start
   # and persisted to /data/.session_secret so sessions survive restarts.
   # To override, add tududi_session_secret manually in the addon config.
+  tududi_trust_proxy: true
+  ff_enable_mcp: false
   disable_telegram: false
   disable_scheduler: false
   upload_path: "/data/uploads"
@@ -41,6 +43,8 @@ schema:
   tududi_user_email: str
   tududi_user_password: str
   tududi_session_secret: str?
+  tududi_trust_proxy: bool
+  ff_enable_mcp: bool
   disable_telegram: bool
   disable_scheduler: bool
   upload_path: str

--- a/tududi-addon-dev/run.sh
+++ b/tududi-addon-dev/run.sh
@@ -158,9 +158,26 @@ export NODE_ENV=production
 # This regression became visible in tududi v1.0.0+ after upstream #1008
 # tied cookie.secure to NODE_ENV (now true here). Defaulting trust proxy on
 # is safe because HA ingress is always the reverse proxy in front of an
-# addon. Upstream context: chrisvel/tududi#1023.
-export TUDUDI_TRUST_PROXY=true
-log_info "Trust proxy enabled for HA ingress"
+# addon. Disable only in advanced non-ingress setups where the upstream
+# proxy is not trusted. Upstream context: chrisvel/tududi#1023.
+TUDUDI_TRUST_PROXY=$(jq --raw-output '.tududi_trust_proxy // true' "$CONFIG_PATH")
+if [ "$TUDUDI_TRUST_PROXY" = "true" ]; then
+    export TUDUDI_TRUST_PROXY=true
+    log_info "Trust proxy enabled for HA ingress"
+else
+    export TUDUDI_TRUST_PROXY=false
+    log_warning "Trust proxy disabled - login will fail behind HA ingress. Only use this for advanced non-ingress setups."
+fi
+
+# MCP server - opt-in upstream feature flag (FF_ENABLE_MCP). When enabled,
+# tududi exposes /api/mcp/* endpoints protected by a Bearer API token.
+# Users must generate an API token in Profile > API Keys to use the server.
+# Defaults to false to match upstream.
+FF_ENABLE_MCP=$(jq --raw-output '.ff_enable_mcp // false' "$CONFIG_PATH")
+if [ "$FF_ENABLE_MCP" = "true" ]; then
+    export FF_ENABLE_MCP=true
+    log_info "MCP server enabled - generate an API token in Profile > API Keys to use /api/mcp/*"
+fi
 
 # Set CORS allowed origins for Home Assistant ingress
 # Use wildcard to allow all origins when behind ingress proxy

--- a/tududi-addon-dev/translations/en.yaml
+++ b/tududi-addon-dev/translations/en.yaml
@@ -11,6 +11,19 @@ configuration:
   tududi_session_secret:
     name: Session Secret
     description: Secret key for session encryption (generate a random string)
+  tududi_trust_proxy:
+    name: Trust Proxy (HA Ingress)
+    description: >-
+      Trust the X-Forwarded-* headers from the reverse proxy. Required for HA
+      Ingress - leave enabled. Only disable for advanced non-ingress setups
+      where the upstream proxy is not trusted; disabling will cause login to
+      fail behind HA Ingress.
+  ff_enable_mcp:
+    name: Enable MCP Server
+    description: >-
+      Expose the Tududi MCP server endpoints (/api/mcp/*). Opt-in and off by
+      default. When enabled, requires a Bearer API token generated in the
+      Tududi UI under Profile > API Keys to call the server.
   disable_telegram:
     name: Disable Telegram
     description: Disable Telegram integration


### PR DESCRIPTION
## Description
Expose two upstream Tududi feature flags as HA addon config toggles: `tududi_trust_proxy` (default `true`, was hardcoded in `.14.1`) and `ff_enable_mcp` (default `false`, new). Friendly names and descriptions added in `translations/en.yaml` so they render cleanly in the HA config UI. Dev addon only.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
    - [ ] was there a feature request, if yes, linked

## Changes Made
- `tududi-addon-dev/config.yaml`: version `1.1.0-dev.14.1` → `1.1.0-dev.14.2`; adds `tududi_trust_proxy: true` and `ff_enable_mcp: false` to `options:` and `schema:` (both `bool`).
- `tududi-addon-dev/run.sh`: replaces the hardcoded `export TUDUDI_TRUST_PROXY=true` with a conditional read from `options.json` (default true — preserves `.14.1` behavior; logs a warning when disabled). Adds an `FF_ENABLE_MCP` block that only exports + logs when the user enables it.
- `tududi-addon-dev/translations/en.yaml`: friendly names + descriptions for the two new options so they render nicely in the HA config UI.
- `tududi-addon-dev/CHANGELOG.md`: new `1.1.0-dev.14.2` entry.
- `tududi-addon-dev/README.md`: updated config table + sample yaml, added "About `tududi_trust_proxy`" and "About `ff_enable_mcp`" subsections (the MCP one documents the Bearer-token requirement and Profile → API Keys flow).

## Testing
- [x] Add-on builds successfully *(verify after running the builder workflow)*
- [ ] Tested in Home Assistant
- [ ] No breaking changes confirmed

## Add-on Affected
- [x] Development addon (`tududi-addon-dev`)

## Checklist
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [x] Documentation updated (if needed)
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Additional Notes
- `tududi_trust_proxy` default stays `true` on purpose — HA Ingress is always a trusted reverse proxy in front of every addon, and defaulting off would re-introduce the 401-after-login regression fixed in `.14.1` (see chrisvel/tududi#1023). Disabling it is intended only for advanced non-ingress setups; `run.sh` logs a warning in that case.
- `ff_enable_mcp` default stays `false` to match upstream. When enabled, `/api/mcp/*` is exposed and protected by a Bearer API token; users need to generate the token in Profile → API Keys before it's useful. Verified upstream at `chrisvel/tududi@v1.1.0-dev.14` in `backend/modules/mcp/routes.js` (`process.env.FF_ENABLE_MCP === 'true'` gate + Bearer middleware).
- Versioning: `1.1.0-dev.14.2` is valid SemVer 2.0 and compares `> 1.1.0-dev.14.1` under HA's `awesomeversion` (SemVer §11.4.4, larger pre-release segment wins with matching prefixes).
- After merge: run the builder workflow targeting `dev` to publish `ghcr.io/c2gl/tududi-addon-dev:1.1.0-dev.14.2`.