### PR TITLE
Bump dev addon to tududi v1.4.0-rc.1

### DIFF
--- a/tududi-addon-dev/CHANGELOG.md
+++ b/tududi-addon-dev/CHANGELOG.md
@@ -2,6 +2,93 @@
 
 All notable changes to this add-on will be documented in this file.
 
+## 1.4.0-rc.1
+**BUMPED:** bumped to tududi v1.4.0-rc.1 (release candidate)
+
+Jump from the previous pin (v1.2.4). Upstream progressed through v1.3.0-rc.1 ->
+v1.3.0 -> v1.3.1 -> v1.4.0-dev.1 -> v1.4.0-rc.1. Addon-relevant analysis first,
+then upstream highlights; full upstream notes:
+https://github.com/chrisvel/tududi/releases
+
+**Addon-relevant:**
+- Node / base image: upstream still builds on `node:22-alpine`, and the addon
+  base image is already Alpine 3.22 (Node 22.16) since `1.2.4.1`. No new
+  ESM-only startup dependency was added, so no `build.yaml` change is needed.
+- New PWA support (#1343) ships `public/sw.js`. Webpack's copy step emits it
+  into `dist/`, so the existing `cp -r dist/*` in the Dockerfile picks it up
+  with no change. However, `frontend/index.tsx` registers the worker at the
+  absolute path `/sw.js` and `manifest.json` uses `start_url`/`scope` of `/`,
+  neither of which resolve behind HA ingress - so PWA install and offline mode
+  will not work through ingress. Upstream catches the registration failure and
+  treats it as non-fatal, so nothing else is affected.
+- Pre-v1.2.0 database handling changed (#1291): `backend/cmd/start.sh` now
+  redirects `DB_FILE` to the old `/app/backend/db` path instead of copying the
+  file to the new location. The addon is unaffected - `run.sh` sets
+  `DB_FILE=/data/production.sqlite3` and the image's `/app/backend/db` is
+  always empty, so that fallback branch never fires.
+- `webpack.config.js` (`publicPath: ''`) and `public/index.html` (dynamic
+  `<base>` tag) are byte-identical to v1.2.4, so the ingress path handling the
+  addon depends on is unchanged and the Dockerfile still needs zero sed fixes.
+- Feature flags unchanged from v1.2.4 (`FF_ENABLE_MCP`, `FF_ENABLE_BACKUPS`,
+  `FF_ENABLE_CALDAV`, `FF_ENABLE_CALENDAR`, `FF_ENABLE_HABITS`), so the
+  `ff_enable_mcp` option and schema stay as they are.
+- The `uuid` dependency was dropped in favour of the Node built-in
+  `crypto.randomUUID()` (#1297). `nanoid@3` and `i18next` are still pinned
+  upstream, so the addon's extra `npm install` lines for them remain no-ops.
+- New optional upstream env vars are not exposed as addon options: templates
+  marketplace (`MARKETPLACE_URL`, `MARKETPLACE_API_KEY`,
+  `PROJECT_TEMPLATES_ENABLED`, `MAX_TEMPLATES_PER_USER`) and multi-LLM AI
+  (`LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`). All have safe defaults.
+- Frontend build verified locally at the `v1.4.0-rc.1` tag using the addon's
+  own flags: `tsc --noEmit` and webpack both pass under the
+  `--max-old-space-size=2048` cap despite the new CodeMirror-based note editor
+  (main bundle ~3.3 MiB).
+
+**Features:**
+- Subtasks are now first-class tasks with list visibility (#1346).
+- Installable PWA with offline read and queued write sync (#1343).
+- Project templates + marketplace (#1278), plus per-user area overrides for
+  shared projects (#1276).
+- GTD-aligned reports page with tabbed layout; sidebar reorganised with pinned
+  items, boards, insights and admin sections (#1306, #1311).
+- Rich note editor with wikilinks, backlinks, slash commands and note badges
+  (#1340); working copy button on markdown code blocks (#1288).
+- Multi-LLM AI support with a dedicated AI settings tab and user profile
+  context (#1333); AI Daily Brief restored with a Today page toggle (#1331).
+- MCP grew to 54 tools - goals, views and people tools added (#1334, #1335).
+- People: User accounts can be linked to Person records, and a self-person is
+  created for newly provisioned users (#1319).
+- Today page gained a `#today` tagged-tasks section with a toggle setting.
+
+**Fixes:**
+- CalDAV: sync direction values aligned with model constraints (#1347); date
+  timezone handling and ETag on collection GET (#1336); externally-synced tasks
+  now viewable.
+- Security: 5 production vulnerabilities patched via overrides and upgrades
+  (#1338), plus a further Dependabot round (#1324).
+- OIDC: UserInfo endpoint queried to supplement ID token claims (#1322); OIDC
+  users can set an initial password without supplying a current one (#1320).
+- Performance: N+1 notification queries no longer block API requests (#1296);
+  `/api/profile` cached to stop redundant fetches on the Today page (#1312).
+- SQLite: `SQLITE_BUSY` on system tag seeding fixed by passing the parent
+  transaction (#1287); `user_project_areas` index creation made idempotent
+  (#1301).
+- MCP: shared-project permissions enforced (#1290); archived task status
+  mapping corrected (#1318); tags persisted on task update (#1328).
+- Habits: completions no longer double-counted in the Today overview or
+  inflated on same-day completions (#1315, #1317).
+- Telegram: due/deferred notifications batched into one message per user
+  (#1329).
+- Recurring tasks: monthly occurrence dates corrected for UTC+ timezones
+  (#1313).
+- Tasks: assigned person embedded in the task response so all users see the
+  assignment (#1341); detail view always fetches fresh data to fix stale
+  due dates on shared projects (#1293).
+
+**Addon files changed:**
+- `Dockerfile`: clone branch `v1.2.4` -> `v1.4.0-rc.1`.
+- `config.yaml`: version `1.2.4.1` -> `1.4.0-rc.1`, updated description.
+
 ## 1.2.4.1
 **FIXED:** startup crash-loop `ERR_REQUIRE_ESM` on v1.2.4
 - Upstream v1.2.4 added `jose` v6 (ESM-only), loaded via `require('jose')` at

--- a/tududi-addon-dev/Dockerfile
+++ b/tududi-addon-dev/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # To update the version, change the branch tag on the git clone line below
-RUN git clone --depth 1 --branch v1.2.4 https://github.com/chrisvel/tududi.git /tmp/tududi && \
+RUN git clone --depth 1 --branch v1.4.0-rc.1 https://github.com/chrisvel/tududi.git /tmp/tududi && \
     cd /tmp/tududi && \
     npm config set fetch-retry-maxtimeout 300000 && \
     npm config set fetch-retry-mintimeout 20000 && \

--- a/tududi-addon-dev/config.yaml
+++ b/tududi-addon-dev/config.yaml
@@ -1,7 +1,7 @@
 name: "Tududi (Development)"
-version: "1.2.4.1"
+version: "1.4.0-rc.1"
 slug: "tududi-dev"
-description: "Development version of Tududi (v1.2.4) - for testing only, may be unstable"
+description: "Development version of Tududi (v1.4.0-rc.1) - for testing only, may be unstable"
 url: "https://github.com/c2gl/tududi-addon"
 image: "ghcr.io/c2gl/tududi-addon-dev"
 init: false


### PR DESCRIPTION
## Description

Bumps the **development** addon from tududi `v1.2.4` (addon `1.2.4.1`) to upstream pre-release **`v1.4.0-rc.1`**. Pure version bump — no addon logic changes; the base image is already Alpine 3.22 (Node 22.16), which satisfies upstream's `node:22-alpine` baseline, and the new upstream PWA asset is picked up by the existing `dist` copy step.

## Type of Change
<!-- Mark relevant options with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
    - [ ] Referenced the bug
- [ ] New feature (non-breaking change which adds functionality)
    - [ ] was there a feature request, if yes, linked
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] CI/CD changes
- [x] Bump Dependancies

## Changes Made
<!-- List the specific changes made in this PR -->
- `tududi-addon-dev/Dockerfile`: clone branch `v1.2.4` → `v1.4.0-rc.1`.
- `tududi-addon-dev/config.yaml`: version `1.2.4.1` → `1.4.0-rc.1`; description updated to name the new upstream version.
- `tududi-addon-dev/CHANGELOG.md`: new `1.4.0-rc.1` entry with the addon-relevant analysis and the upstream highlights for `v1.3.0-rc.1` → `v1.3.0` → `v1.3.1` → `v1.4.0-dev.1` → `v1.4.0-rc.1`.

No change needed to `build.yaml`, `run.sh`, `translations/` or the option schema — see Additional Notes.

## Testing
<!-- Describe how you tested these changes -->
- [x] Local testing completed
- [ ] Add-on builds successfully
- [ ] Tested in Home Assistant
- [x] No breaking changes confirmed

Local verification performed against the `v1.4.0-rc.1` tag with the addon's own build flags (`npm install --legacy-peer-deps`, then `NODE_OPTIONS=--max-old-space-size=2048 NODE_ENV=production npm run frontend:build`):

- `tsc --noEmit` passes; webpack compiles with only bundle-size warnings (main bundle ~3.3 MiB, up from v1.2.4 — the new CodeMirror note editor). **The 2048 MB heap cap is still sufficient**, so the Dockerfile's `NODE_OPTIONS` does not need raising.
- `dist/` contains the new `sw.js` and updated `manifest.json`, confirming webpack's copy step emits `public/sw.js` — the addon's existing `cp -r dist/*` picks it up with no Dockerfile change.
- `webpack.config.js` (`publicPath: ''`) and `public/index.html` (dynamic `<base>` tag) are **byte-identical** to v1.2.4, so the ingress path handling the addon relies on is unchanged and no `sed` fixes are reintroduced.

Add-on image build (builder workflow) and in-HA verification still to be done after merge.

## Add-on Affected
<!-- Mark which addon(s) are affected -->
- [ ] Stable addon (`tududi-addon`)
- [x] Development addon (`tududi-addon-dev`)
- [ ] Repository configuration
- [ ] CI/CD workflows

## Checklist
<!-- Mark completed items with an "x" -->
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Documentation updated (if needed)
- [x] Changelog updated (if needed)
- [x] Version number updated (if needed)

## Screenshots (if applicable)

n/a

## Additional Notes

**Why no other addon files change**

- **Node / base image:** upstream still builds on `node:22-alpine`. The dev addon's `build.yaml` is already Alpine 3.22 (Node 22.16) after `1.2.4.1`, so the `ERR_REQUIRE_ESM` class of problem cannot recur here. No new ESM-only startup dependency was added.
- **Feature flags:** the upstream flag set is unchanged from v1.2.4 (`FF_ENABLE_MCP`, `FF_ENABLE_BACKUPS`, `FF_ENABLE_CALDAV`, `FF_ENABLE_CALENDAR`, `FF_ENABLE_HABITS`), so the existing `ff_enable_mcp` option and schema stay as they are.
- **Data paths:** upstream `backend/cmd/start.sh` changed its pre-v1.2.0 fallback to *redirect* `DB_FILE` to the old `/app/backend/db` path instead of copying it (chrisvel/tududi#1291). The addon is unaffected — `run.sh` sets `DB_FILE=/data/production.sqlite3` and the image's `/app/backend/db` is always empty, so the fallback branch never fires.
- **Dropped `uuid` dependency** (replaced by the Node built-in `crypto.randomUUID()`, chrisvel/tududi#1297) needs no addon action. `nanoid@3` and `i18next` are still pinned in upstream `package.json`, so the addon's belt-and-braces `npm install` lines for them remain harmless no-ops (removing them would be a reasonable separate cleanup).

**Known upstream limitation: PWA does not work behind HA ingress**

v1.4.0-dev.1 added an installable PWA with offline read and queued write sync (chrisvel/tududi#1343). Behind HA ingress it will not activate:

- `frontend/index.tsx` calls `navigator.serviceWorker.register('/sw.js')` — an absolute path, which under ingress resolves to the Home Assistant root rather than the addon, so the request 404s.
- `public/manifest.json` uses `"start_url": "/"` and `"scope": "/"`, which are likewise wrong under an ingress sub-path.

This is **non-fatal**: upstream wraps the registration in a `.catch()` that explicitly treats failure as "app functions without service worker", so the addon behaves exactly as it does today, minus PWA install and offline mode. It's the same class of bug as the logo paths fixed in chrisvel/tududi#946 and the right fix is upstream (derive the SW URL and manifest scope from the existing base-path helper). Happy to raise that upstream as a follow-up if you agree.

**New upstream config surface, not yet exposed as addon options**

v1.3.x introduced optional env vars for the project-templates marketplace (`MARKETPLACE_URL`, `MARKETPLACE_API_KEY`, `PROJECT_TEMPLATES_ENABLED`, `MAX_TEMPLATES_PER_USER`) and multi-LLM AI support (`LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`). All have safe defaults (templates enabled with local-only templates, AI inert without a key), so this PR leaves them alone. Exposing the AI ones as addon options is a plausible follow-up if there's demand.

**After merge**

Run **Actions → 🏗️📢 Build and Publish Add-on → `dev`** to publish `ghcr.io/c2gl/tududi-addon-dev:1.4.0-rc.1`. Note this is an upstream *release candidate*, so the dev addon is doing exactly its job here — worth a round of in-HA smoke testing (login via ingress, subtasks, the new notes editor and reports page) before considering a stable promotion.